### PR TITLE
<utility> header; move, forward, remove_reference implementation

### DIFF
--- a/bits/remove_reference.hpp
+++ b/bits/remove_reference.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+namespace std {
+
+	template <class T>
+	struct remove_reference { typedef T type; };
+
+	template <class T>
+	struct remove_reference<T&> { typedef T type; };
+
+	template <class T>
+	struct remove_reference<T&&> { typedef T type; };
+
+}

--- a/type_traits
+++ b/type_traits
@@ -21,6 +21,7 @@
 #include <exception>
 #include <memory>
 #include <char_traits>
+#include <bits/remove_reference.hpp>
 
 #ifndef __HEADER_TYPE_TRAITS
 #define __HEADER_TYPE_TRAITS 1
@@ -92,15 +93,6 @@ namespace std{
 	template <>
 	struct enable_if<false>
 	{};
-
-	template <class T>
-	struct remove_reference { typedef T type; };
-
-	template <class T>
-	struct remove_reference<T&> { typedef T type; };
-
-	template <class T>
-	struct remove_reference<T&&> { typedef T type; };
 }
 
 #pragma GCC visibility pop

--- a/type_traits
+++ b/type_traits
@@ -92,6 +92,15 @@ namespace std{
 	template <>
 	struct enable_if<false>
 	{};
+
+	template <class T>
+	struct remove_reference { typedef T type; };
+
+	template <class T>
+	struct remove_reference<T&> { typedef T type; };
+
+	template <class T>
+	struct remove_reference<T&&> { typedef T type; };
 }
 
 #pragma GCC visibility pop

--- a/utility
+++ b/utility
@@ -1,0 +1,1 @@
+#include <utility.h>

--- a/utility.h
+++ b/utility.h
@@ -26,7 +26,7 @@
 
 #pragma GCC visibility push(default)
 
-namespace std{
+namespace std {
 
 	namespace rel_ops {
 		template<class T> inline bool operator!=(const T& x, const T& y){
@@ -80,6 +80,17 @@ namespace std{
 		return pair<T1,T2>(x, y);
 	}
 
+	namespace detail {
+		template<typename T>
+		struct identity {
+	    	typedef T type;
+		};
+	}
+
+	template<typename T>
+	T&& forward(typename detail::identity<T>::type&& param) {
+		return static_cast<typename detail::identity<T>::type&&>(param);
+	}
 
 }
 

--- a/utility.h
+++ b/utility.h
@@ -19,7 +19,7 @@
 
 
 #include <basic_definitions>
-
+#include <bits/remove_reference.hpp>
 
 #ifndef __STD_HEADER_UTILITY
 #define __STD_HEADER_UTILITY 1

--- a/utility.h
+++ b/utility.h
@@ -92,6 +92,12 @@ namespace std {
 		return static_cast<typename detail::identity<T>::type&&>(param);
 	}
 
+	template <typename T>
+	typename remove_reference<T>::type&& move(T&& arg)
+	{
+		return static_cast<typename remove_reference<T>::type&&>(arg);
+	}
+
 }
 
 #pragma GCC visibility pop


### PR DESCRIPTION
* Added the `<utility>` header that simply includes already existing `utility.h`.
* Added `std::forward` implementation (`<utility>`) .
* Added `std::move` implementation (`<utility>`) .
* Added `std::remove_reference` implementation (`<type_traits>`) - required for `std::move`.